### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ git clone https://github.com/FlagAlpha/Llama2-Chinese.git
 
 cd Llama2-Chinese
 
-sudo docker build -f docker/Dockerfile  -t FlagAlpha/llama2-chinese-7b:gradio .
+docker build -f docker/Dockerfile -t flagalpha/llama2-chinese-7b:gradio .
 ```
 
 第二步：通过docker-compose启动chat_gradio


### PR DESCRIPTION
执行([root@PS2021WWURSRXY /data/Llama2-Chinese-main]# docker build -f docker/Dockerfile  -t FlagAlpha/llama2-chinese-7b:gradio . invalid argument "FlagAlpha/llama2-chinese-7b:gradio" for "-t, --tag" flag: invalid reference format: repository name must be lowercase See 'docker build --help'.)报错.
Docker 镜像名称要求使用小写字母。根据错误信息显示，镜像名称中包含大写字母，所以需要将镜像名称中的大写字母改成小写字母。解决方法是：

将镜像名称 "FlagAlpha/llama2-chinese-7b:gradio" 中的大写字母全部改为小写字母，比如可以改成 "flagalpha/llama2-chinese-7b:gradio"。然后重新运行构建命令。

正确的构建命令应该是：
sudo docker build -f docker/Dockerfile -t flagalpha/llama2-chinese-7b:gradio .