### PR TITLE
fixed: bitsandbytes exception on windows platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-bitsandbytes==0.39.0
+bitsandbytes==0.41.1; platform_system != "Windows"
+https://github.com/jllllll/bitsandbytes-windows-webui/releases/download/wheels/bitsandbytes-0.41.1-py3-none-win_amd64.whl; platform_system == "Windows"
 accelerate==0.21.0
 #deepspeed==0.10.0
 git+https://github.com/PanQiWei/AutoGPTQ.git


### PR DESCRIPTION
auto decided install bitsandbytes package on windows/linux plaform
```
pip uninstall bitsandbytes
pip install https://github.com/jllllll/bitsandbytes-windows-webui/releases/download/wheels/bitsandbytes-0.41.1-py3-none-win_amd64.whl
```
